### PR TITLE
initialize splash_ptr and fix a crash

### DIFF
--- a/app/moboot/moboot.c
+++ b/app/moboot/moboot.c
@@ -26,8 +26,14 @@
  * SUCH DAMAGE.
  */
 
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
 #include <app.h>
 #include <debug.h>
+#include <platform.h>
+#include <kernel/thread.h>
 #include <target/gpiokeys.h>
 #include <target/restart.h>
 #include <dev/fbcon.h>
@@ -36,6 +42,8 @@
 #include <lib/fs.h>
 #include <lib/tga.h>
 #include <lib/gfxconsole.h>
+#include <lib/atags.h>
+#include <lib/ramdisk.h>
 #include <lib/bootlinux.h>
 
 typedef struct menu_entry
@@ -263,7 +271,7 @@ void moboot_init(const struct app_descriptor *app)
 	ramdisk_mounted = 0;
 	atags_get_ramdisk(&ramdisk_start, &ramdisk_size);
 	if (ramdisk_size && ramdisk_start) {
-		ramdisk_init(ramdisk_start, ramdisk_size);
+		ramdisk_init((void*)ramdisk_start, ramdisk_size);
 		if (fs_mount("/ramdisk", "/dev/ramdisk")) {
 			printf("Ramdisk start=%08x size=%08x\n", ramdisk_start, ramdisk_size);
 			printf("Unable to mount /ramdisk\n");
@@ -519,7 +527,6 @@ void moboot_init(const struct app_descriptor *app)
 					}
 
 					if (splash_ptr) free(splash_ptr);
-
 
 					/* check for splash image */
 					sprintf(splash_path, "/boot/moboot.splash.%s.tga", 

--- a/app/moboot/moboot.c
+++ b/app/moboot/moboot.c
@@ -237,7 +237,7 @@ void moboot_init(const struct app_descriptor *app)
 	unsigned counted_images;
 	unsigned use_next;
 	ssize_t splash_sz;
-	void *splash_ptr;
+	void *splash_ptr = NULL;
 	ssize_t background_sz;
 	void *background_ptr;
 	ssize_t tile_sz;

--- a/include/debug.h
+++ b/include/debug.h
@@ -88,6 +88,8 @@ void hexdump8(const void *ptr, size_t len);
 #define LTRACE do { if (LOCAL_TRACE) { TRACE; } } while (0)
 #define LTRACEF(x...) do { if (LOCAL_TRACE) { TRACEF(x); } } while (0)
 
+void register_debug_output(void (*fn)(char c));
+
 #if defined(__cplusplus)
 }
 #endif

--- a/include/lib/atags.h
+++ b/include/lib/atags.h
@@ -167,6 +167,7 @@ struct tag {
 extern char * atags_nduid(unsigned *tags_ptr);
 extern char * atags_get_cmdline_arg(unsigned *tags_ptr, const char *arg);
 extern void init_passed_atags(unsigned *tags);
+extern void atags_get_ramdisk(unsigned *addr, unsigned *length);
 
 #endif
 

--- a/include/lib/bootlinux.h
+++ b/include/lib/bootlinux.h
@@ -35,6 +35,9 @@ extern void bootlinux_atags(void *kernel, unsigned *tags,
 		const char *cmdline, unsigned machtype,
 		void *ramdisk, unsigned ramdisk_size);
 
+extern unsigned bootlinux_uimage_mem(void *data, unsigned len, void (*callback)(),
+		unsigned flags);
+
 enum {
 	BOOTLINUX_NOFLAGS = 0,
 	BOOTLINUX_VERBOSE,

--- a/include/lib/font.h
+++ b/include/lib/font.h
@@ -8,6 +8,7 @@
 #define FONT_COLS 2
 
 void font_draw_char(gfx_surface *surface, unsigned char c, int x, int y, uint32_t fg_color, uint32_t bg_color);
+void font_draw_char_trans(gfx_surface *surface, unsigned char c, int x, int y, uint32_t fg, gfx_surface *bg_surface);
 
 #endif
 

--- a/include/lib/gfxconsole.h
+++ b/include/lib/gfxconsole.h
@@ -6,5 +6,14 @@
 void gfxconsole_start_on_display(void);
 void gfxconsole_start(gfx_surface *surface);
 
+void gfxconsole_clear(void);
+void gfxconsole_setpos(unsigned x, unsigned y);
+void gfxconsole_set_colors(uint32_t bg, uint32_t fg);
+unsigned gfxconsole_getwidth();
+unsigned gfxconsole_getheight();
+
+void gfxconsole_settrans(unsigned val);
+
+void gfxconsole_setbackground(gfx_surface *bgs);
 #endif
 

--- a/lib/ramdisk/ramdisk.c
+++ b/lib/ramdisk/ramdisk.c
@@ -13,7 +13,7 @@ ssize_t ramdisk_bio_write_block(struct bdev *dev, const void *buf, bnum_t block,
 unsigned char *ramdisk_loc;
 
 
-void ramdisk_init(unsigned loc, unsigned size)
+void ramdisk_init(void *loc, unsigned size)
 {
 
 	ramdisk_loc = (unsigned char *)loc;


### PR DESCRIPTION
without initialization, it crashes when it is free'ed later on.
fs_load_file_mem(splash_path, &splash_ptr) could fail and leaves an
initialized pointer.
